### PR TITLE
Update readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# EtherGuild Community Project Assets
+# EtherGuild Community Project Artifacts
 
-This repository contains assets and source code for the EtherGuild cryptocurrency community project. It is primarily intended to store source files for 3D printed swag, images, and related materials.
+![Code of Arms](images/code_of_arms.png)
+
+This repository contains artifacts and source code for the EtherGuild cryptocurrency community project. It is primarily intended to store source files for 3D printed swag, images, and related materials.
 
 ## Structure
 - `models/` — Finished 3D model files (STL) for prototypes and printable swag. Current models include:
   - EtherGuild badge designed for a bracelet or wristwatch-style strap ("oathband" prototypes)
   - Other badge and bracelet prototypes
 - `images/` — Renders, logos, and reference images
-- `src/` — Source files for asset creation. Currently contains:
-  - An OpenSCAD file for the Ethereum logo on a "EtherGuild" badge background (badge-v001.scad)
+- `src/` — Source files for artifact creation. Currently contains:
+  - An OpenSCAD file for the EtherGuild logo on a "EtherGuild" badge background (badge-v001.scad)
 
 Feel free to contribute new designs, scripts, or ideas for EtherGuild swag! If you have new badge or band concepts, add your SCAD or STL files to the appropriate directory.
 


### PR DESCRIPTION
Fixes #1

Update the README file to use the term 'artifacts' for in real life items and 'EtherGuild' instead of 'ethereum guild', and include the code of arms image at the top.

* Change the title to "EtherGuild Community Project Artifacts".
* Add the code of arms image to the top of the file.
* Replace instances of "assets" with "artifacts".
* Replace instances of "ethereum guild" with "EtherGuild".
* Update the description of the `src/` directory to reflect the new terminology.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jmcpheron/etherguild-irl/pull/2?shareId=8afae6dd-4328-4646-ae61-343fc59f7c5d).